### PR TITLE
Add Session.screenshot coroutine

### DIFF
--- a/docs/reference/session.rst
+++ b/docs/reference/session.rst
@@ -213,6 +213,12 @@
         Coroutine to perform a series of actions. Use :py:func:`arsenic.actions.chain`
         to build the actions object.
 
+    .. py:method:: screenshot
+
+        Coroutine to take a screenshot of the top-level browsing context’s viewport.
+
+        :rtype: bytes
+
     .. py:method:: close
 
         Coroutine to close this session.

--- a/src/arsenic/session.py
+++ b/src/arsenic/session.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, Any, List, Dict, Tuple, Iterator
 
 import attr
+import base64
 import itertools
 
 from arsenic.connection import Connection, WEB_ELEMENT
@@ -294,6 +295,12 @@ class Session:
             method='POST',
             data=actions
         )
+
+    async def screenshot(self):
+        return base64.b64decode(await self.connection.request(
+            url='/screenshot',
+            method='GET'
+        ))
 
     async def close(self):
         await self.connection.request(


### PR DESCRIPTION
Coroutine to take a screenshot of the top-level browsing context’s viewport.

It also does b64decode so it returns bytes to the user instead of base64 encoded str.