### PR TITLE
Fix DeprecationWarning: aiohttp.ClientSession.close() is a coroutine

### DIFF
--- a/src/arsenic/services.py
+++ b/src/arsenic/services.py
@@ -29,12 +29,6 @@ async def stop_process(process):
         pass
 
 
-def sync_factory(func):
-    async def sync():
-        func()
-    return sync
-
-
 async def tasked(coro):
     return await asyncio.get_event_loop().create_task(coro)
 
@@ -75,7 +69,7 @@ async def subprocess_based_service(cmd: List[str],
         )
         closers.append(partial(stop_process, process))
         session = ClientSession()
-        closers.append(sync_factory(session.close))
+        closers.append(session.close)
         count = 0
         while True:
             try:
@@ -179,7 +173,7 @@ class Remote(Service):
             headers.update(self.auth.get_headers())
         try:
             session = ClientSession(headers=headers)
-            closers.append(sync_factory(session.close))
+            closers.append(session.close)
             return WebDriver(RemoteConnection(session, self.url), closers)
         except:
             for closer in reversed(closers):


### PR DESCRIPTION
Using arsenic, I get this warning: 

    .../lib/python3.6/site-packages/arsenic/services.py:34: DeprecationWarning: ClientSession.close() is a coroutine

This is happening because aiohttp changed ClientSession.close() to a coroutine. http://aiohttp.readthedocs.io/en/stable/changes.html#id9

This patch fixes this.
