### PR TITLE
Selenium-like Element screenshot

### DIFF
--- a/src/arsenic/session.py
+++ b/src/arsenic/session.py
@@ -118,6 +118,11 @@ class Element(RequestHelpers):
         data = await self._request(url="/rect", method="GET")
         return Rect(data["x"], data["y"], data["width"], data["height"])
 
+    async def get_screenshot(self):
+        return BytesIO(
+            base64.b64decode(await self._request(url="/screenshot", method="GET"))
+        )
+
 
 TCallback = Callable[..., Awaitable[Any]]
 TWaiter = Callable[[int, TCallback], Awaitable[Any]]


### PR DESCRIPTION
Selenium WebElements implements 3 properties called **screenshot_as_base64**, **screenshot_as_png** and **screenshot**.

Arsenic has those functions in its session.py implementation, but it can only takes a screenshot to the browser visible content. We can't simply take a screenshot of a desired element. So this new method **get_screenshot** for the class **Element** solves the pain of doing the steps of locating and cropping for each one of them. 

Proof of concept: 

```python

import asyncio
from arsenic import get_session, browsers, services


async def hello_world():
    service = services.Chromedriver()
    browser = browsers.Chrome())
    async with get_session(service, browser) as session:
        await session.get('https://www.google.com')
        logo = await session.wait_for_element(5, 'img[id=hplogo]')
        img = await logo.get_screenshot()
        
        with open('screenshot.png', 'wb') as png:
            png.write(img.read())

def main():
    loop = asyncio.get_event_loop()
    loop.run_until_complete(hello_world())


if __name__ == '__main__':
    main()

```

Result:
![screenshot](https://user-images.githubusercontent.com/6425132/53304860-5a949b00-3848-11e9-97dd-91b24f9ee58b.png)
