### PR TITLE
Handle errors even on HTTP 200

### DIFF
--- a/src/arsenic/constants.py
+++ b/src/arsenic/constants.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 WEB_ELEMENT = "element-6066-11e4-a52e-4f735466cecf"
 
+STATUS_SUCCESS = 0
+
 
 class SelectorType(Enum):
     css_selector = "css selector"

--- a/src/arsenic/webdriver.py
+++ b/src/arsenic/webdriver.py
@@ -56,15 +56,13 @@ class WebDriver:
                 err_resp["error"], err_resp.get("message", ""), original_response
             )
         session_id = response["sessionId"]
-        session = browser.session_class(
+        return browser.session_class(
             connection=self.connection.prefixed(f"/session/{session_id}"),
             bind=bind,
             wait=self.wait,
             driver=self,
             browser=browser,
         )
-        session._check_response_error(status, response)
-        return session
 
     async def close(self):
         for closer in reversed(self.closers):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,13 +96,11 @@ async def get_remote_session(root_url: str):
         raise pytest.skip("No remote browser configured (REMOTE_BROWSER)")
     if "REMOTE_SERVICE" not in os.environ:
         raise pytest.skip("No remote service configured (REMOTE_SERVICE)")
-    if "BROWSERSTACK_API_KEY" in os.environ:
-        context = bsl_context
-    else:
-        context = null_context
+    if "BROWSERSTACK_API_KEY" not in os.environ:
+        raise pytest.skip("No browserstack api key configured (BROWSERSTACK_API_KEY)")
     remote_browser = json.loads(os.environ["REMOTE_BROWSER"])
     browser_cls = getattr(browsers, remote_browser["browserName"])
-    with context():
+    with bsl_context():
         async with get_session(
             services.Remote(url=os.environ["REMOTE_SERVICE"]),
             browser_cls(**remote_browser),


### PR DESCRIPTION
Looks like in some cases (eg browserstack) errors can be hidden inside 200 responses.
Close #100