### PR TITLE
Upgrade pillow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 18.9b0
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
     hooks:
     - id: black
-      args: [--line-length=88, --safe]
-      language: python_venv
-      language_version: python3
-      files: ^(src/.*\.py|tests/.*\.py|setup\.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ jinja2 = "^2.11.2"
 pytest = "^6.0.1"
 pytest-asyncio = "^0.14.0"
 sphinx = "^3.2.1"
-pillow = "^7.2.0"
 pytest-cov = "^2.10.1"
 asyncio-extras = "^1.3.2"
 pre-commit = "^2.7.1"
 black = "^20.8b1"
+Pillow = "^8.1.0"
 
 [tool.poetry.scripts]
 arsenic-check-ie11 = "arsenic.helpers:check_ie11_environment_cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 python = "^3.7"
 attrs = ">=17.4.0"
 structlog = "^20.1.0"
-aiohttp = ">=2"
+aiohttp = ">=3"
 
 [tool.poetry.dev-dependencies]
 jinja2 = "^2.11.2"


### PR DESCRIPTION
* `Pillow ^8` because `Pillow ^7` cannot be built on Big Sur dual-arch
* `aiohttp>=3` because `aiohttp==2.3.10` fails with `ImportError: cannot import name 'TCPSite' from 'aiohttp.web'`