### PR TITLE
Negative results from WebDriver are not Errors

### DIFF
--- a/src/arsenic/errors.py
+++ b/src/arsenic/errors.py
@@ -76,6 +76,9 @@ IMEEngineActivationFailed = create("ime engine activation failed", 31)
 InvalidSelector = create("invalid selector", 32)
 MoveTargetOutOfBounds = create("move target out of bounds", 34)
 
+# exceptions that may indicate errors within arsenic
+ERROR_CLASSES = (UnknownArsenicError, UnknownCommand, UnknownError)
+
 
 def raise_exception(data: Dict[str, Any], status: int):
     error = None
@@ -94,12 +97,13 @@ def raise_exception(data: Dict[str, Any], status: int):
     stacktrace = data.get("stacktrace", None)
     screen = data.get("screen", None)
     exception_class = get(error)
-    log.error(
-        "error",
-        type=exception_class,
-        message=message,
-        stacktrace=stacktrace,
-        data=data,
-        status=status,
-    )
+    if exception_class in ERROR_CLASSES:
+        log.error(
+            "error",
+            type=exception_class,
+            message=message,
+            stacktrace=stacktrace,
+            data=data,
+            status=status,
+        )
     raise exception_class(message, screen, stacktrace)


### PR DESCRIPTION
...or put another way, correctly transporting errors is not itself
an error.

For example, in many test situations the most likely message traffic
between Arsenic and WebDriver will be "NoSuchElement" as test
implementations sit in wait_for_element() polling loops.  These
exceptions are mischaracterized as "errors," resulting in noisy log
output--and confusion.

Logging all exceptions that occur also results in double-logging,
since responses are already logged.