### PR TITLE
Improve waiting for subprocess-based services to start

### DIFF
--- a/docs/reference/services.rst
+++ b/docs/reference/services.rst
@@ -18,13 +18,14 @@
     require coroutines.
 
 
-.. py:function:: subprocess_baed_service(cmd, service_url, log_file)
+.. py:function:: subprocess_based_service(cmd, service_url, log_file, start_timeout=15)
 
     Helper function for services that run a local subprocess.
 
     :param List[str] cmd: Command to run.
     :param str service_url: URL at which the service will be available after starting.
     :param io.TextIO log_file: Log file for the service.
+    :param float start_timeout: Optional service started timeout.
     :rtype: :py:class:`arsenic.webdriver.WebDriver`
 
 
@@ -39,21 +40,32 @@
         :rtype: :py:class:`arsenic.webdriver.WebDriver`
 
 
-.. py:class:: Geckodriver(log_file=os.devnull, binary='geckodriver')
+.. py:class:: Geckodriver(log_file=os.devnull, binary='geckodriver', version_check=True, start_timeout=15)
 
     Geckodriver service. Requires geckodriver 0.17 or higher.
 
     :param io.TextIO log_file: Log file to use.
     :param str binary: Path to the geckodriver binary.
     :param bool version_check: Optional flag to disable version checking.
+    :param float start_timeout: Optional service started timeout.
 
 
-.. py:class:: Chromedriver(log_file=os.devnull, binary='chromedriver')
+.. py:class:: Chromedriver(log_file=os.devnull, binary='chromedriver', start_timeout=15)
 
     Chromedriver service.
 
     :param io.TextIO log_file: Log file to use.
     :param str binary: Path to the chromedriver binary.
+    :param float start_timeout: Optional service started timeout.
+
+
+.. py:class:: MSEdgeDriver(log_file=os.devnull, binary='msedgedriver', start_timeout=15)
+
+    Microsoft Edge Driver service.
+
+    :param io.TextIO log_file: Log file to use.
+    :param str binary: Path to the msedgedriver binary.
+    :param float start_timeout: Optional service started timeout.
 
 
 .. py:class:: Remote(url, auth=None)
@@ -65,9 +77,10 @@
     :type auth: :py:class:`arsenic.http.Auth` or :py:class:`str`.
 
 
-.. py:class:: IEDriverServer(log_file=os.devnull, binary='IEDriverServer.exe')
+.. py:class:: IEDriverServer(log_file=os.devnull, binary='IEDriverServer.exe', start_timeout=15)
 
     Internet Explorer service.
 
     :param io.TextIO log_file: Log file to use.
     :param str binary: Path to the IEDriverServer binary.
+    :param float start_timeout: Optional service started timeout.


### PR DESCRIPTION
Use an asyncio.wait_for timeout instead of retrying a fixed number
of times.

Also make service state check interval configurable and pass this
and timeout options up to subprocess-based Service()
implementations.

At timeout raise an ArsenicError instead of a generic Exception so
that applications can catch these errors better and decide what to
do next.