### PR TITLE
Add get_property

### DIFF
--- a/docs/reference/session.rst
+++ b/docs/reference/session.rst
@@ -54,6 +54,13 @@
         :param str name: Name of the attribute to get.
         :rtype: str
 
+    .. py:method:: get_property(name)
+
+        Coroutine which returns the value of a given property of this element.
+
+        :param str name: Name of the property to get.
+        :rtype: str
+
     .. py:method:: select_by_value(value)
 
         Coroutine to select an option by value. This is useful if this element is a select

--- a/src/arsenic/session.py
+++ b/src/arsenic/session.py
@@ -86,6 +86,9 @@ class Element(RequestHelpers):
     async def get_attribute(self, name: str) -> str:
         return await self._request(url=f"/attribute/{name}", method="GET")
 
+    async def get_property(self, name: str) -> str:
+        return await self._request(url=f"/property/{name}", method="GET")
+
     async def get_css_value(self, name: str) -> str:
         return await self._request(url=f"/css/{name}", method="GET")
 


### PR DESCRIPTION
Chromedriver versions 91+ in non w3c mode get_attribute no longer
returns properties first before trying attributes.