### PR TITLE
Migrate to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,5 @@ arsenic-check-ie11 = "arsenic.helpers:check_ie11_environment_cli"
 arsenic-configure-ie11 = "arsenic.helpers:configure_ie11_environment_cli"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
[`poetry-core`](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

Using `poetry-core` allows distribution packages to depend only on the build backend.

It's relevant for distribution packages like Nixpkgs. Looks like that I closed #160 and can't re-open it.